### PR TITLE
Fix segments name

### DIFF
--- a/server/ModelLoader/VrmlWriter.cpp
+++ b/server/ModelLoader/VrmlWriter.cpp
@@ -137,7 +137,7 @@ void VrmlWriter::writeLink(int index, std::ostream &ofs)
     m_indent -= 2;
     indent(ofs); ofs << "]" << std::endl;
     m_indent -= 2;
-    indent(ofs); ofs << "} #Joint" << linfo.name << std::endl;
+    indent(ofs); ofs << "} #Joint " << linfo.name << std::endl;
 }
 
 void VrmlWriter::writeShape(TransformedShapeIndex &tsi, std::ostream &ofs)


### PR DESCRIPTION
export-vrml で セグメントの名前が，'joint_name'_s になっていたのを，
最初のセグメントの名前にするようにしました．
wrl -> wrl へ変換したときに，segmentの名前が変わらないようになりました．
