### PR TITLE
[Eigen3d.h] use 1.0e-12 instaed of 1.0e-6 for error check

### DIFF
--- a/hrplib/hrpUtil/Eigen3d.cpp
+++ b/hrplib/hrpUtil/Eigen3d.cpp
@@ -63,7 +63,7 @@ Vector3 hrp::omegaFromRot(const Matrix33& r)
 
     double alpha = (r(0,0) + r(1,1) + r(2,2) - 1.0) / 2.0;
 
-    if(fabs(alpha - 1.0) < 1.0e-6) {   //th=0,2PI;
+    if(fabs(alpha - 1.0) < 1.0e-12) {   //th=0,2PI;
         return Vector3::Zero();
 
     } else {


### PR DESCRIPTION
これ，むかしなんか議論があった（今の値は今の値で通っているからOKみたいな．．．？）あったきがします．引数でかえたほうがいいでしょうか．