### PR TITLE
[export-vrml] add --use-inline-shape option to output separate mesh file...

### DIFF
--- a/server/ModelLoader/VrmlWriter.h
+++ b/server/ModelLoader/VrmlWriter.h
@@ -7,7 +7,9 @@
 class VrmlWriter
 {
 public:
+    VrmlWriter() : m_use_inline_shape(false) {};
     void write(OpenHRP::BodyInfo_var binfo, std::ostream &ofs);
+    void useInlineShape(bool use_inline);
 private:
     void writeProtoNodes(std::ostream &ofs);
     void writeHumanoidNode(OpenHRP::BodyInfo_var binfo, std::ostream &ofs);
@@ -15,6 +17,7 @@ private:
     void writeShape(OpenHRP::TransformedShapeIndex &tsi, std::ostream &ofs);
     void indent(std::ostream &ofs);
     int m_indent;
+    bool m_use_inline_shape;
     OpenHRP::LinkInfoSequence_var links;
     OpenHRP::ShapeInfoSequence_var shapes;
     OpenHRP::AppearanceInfoSequence_var appearances;

--- a/server/ModelLoader/exportVrml.cpp
+++ b/server/ModelLoader/exportVrml.cpp
@@ -9,11 +9,20 @@ using namespace OpenHRP;
 int main(int argc, char* argv[])
 {
     if (argc < 2){
-        cerr << "Usage:" << argv[0] << "URL of the original file" 
+        cerr << "Usage:" << argv[0] << " <URL of the original file> [--use-inline-shape]"
              << std::endl;
         return 1;
     }
 
+    bool use_inline = false;
+    if (argc > 2) {
+        for (int i = 2; i < argc; i++) {
+            std::string arg (argv[i]);
+            if (arg == "--use-inline-shape") {
+                use_inline = true;
+            }
+        }
+    }
     CORBA::ORB_var orb;
   
     try {
@@ -23,6 +32,7 @@ int main(int argc, char* argv[])
         binfo = ml->getBodyInfo(argv[1]);
 
         VrmlWriter writer;
+        writer.useInlineShape(use_inline);
         writer.write(binfo, cout);
     }catch(ModelLoader::ModelLoaderException ex){
         std::cerr << ex.description << std::endl;


### PR DESCRIPTION
export-vrmlに--use-inline-shape オプションを追加して、メッシュファイルがInlineを使って別ファイルとして書き出されるようにしました。オプションを付けない時の動作は同じです。