### PR TITLE
add note about project-generator behavior

### DIFF
--- a/server/ModelLoader/projectGenerator.cpp
+++ b/server/ModelLoader/projectGenerator.cpp
@@ -291,6 +291,8 @@ private:
   ExtraJointInfoSequence_var extraJointInfoSeq;
 };
 
+// NOTE
+// This program generate xxx.xml, xxx.conf and xxx.RobotHardware.conf at the same time.
 int main (int argc, char** argv)
 {
   std::string output;


### PR DESCRIPTION
project-generatorが同時にxml / conf / RobotHardware.conf を同じディレクトリに作ることを知らず，はまってしまったので，コメント分を追加してみました．