### PR TITLE
layout python stub to right place

### DIFF
--- a/hrplib/hrpCorba/CMakeLists.txt
+++ b/hrplib/hrpCorba/CMakeLists.txt
@@ -82,6 +82,8 @@ execute_process(
   OUTPUT_VARIABLE python_version
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-
-set(idl_py_files ${idl_py_files} ${CMAKE_CURRENT_BINARY_DIR}/OpenHRP/__init__.py)
-install(FILES ${idl_py_files} DESTINATION lib/python${python_version}/dist-packages/OpenHRP)
+install(FILES ${idl_py_files} DESTINATION lib/python${python_version}/dist-packages)
+set(module_py_files ${CMAKE_CURRENT_BINARY_DIR}/OpenHRP/__init__.py)
+install(FILES ${module_py_files} DESTINATION lib/python${python_version}/dist-packages/OpenHRP)
+set(module_poa_py_files ${CMAKE_CURRENT_BINARY_DIR}/OpenHRP__POA/__init__.py)
+install(FILES ${module_poa_py_files} DESTINATION lib/python${python_version}/dist-packages/OpenHRP__POA)


### PR DESCRIPTION
fkanehiro/hrpsys-base#764 であれこれ書いているpython stubのファイルレイアウトに関する修正です。