### PR TITLE
hrplib/hrpPlanner/TimeUtil.cpp : fix get_tick() for arm processors

### DIFF
--- a/hrplib/hrpPlanner/TimeUtil.cpp
+++ b/hrplib/hrpPlanner/TimeUtil.cpp
@@ -8,10 +8,24 @@ tick_t get_tick()
     LARGE_INTEGER t;
     QueryPerformanceCounter(&t);
     return t.QuadPart;
-#else
+#elif  defined(__x86_64__) || defined(__amd64__)
     unsigned int l=0,h=0;
     __asm__ __volatile__("rdtsc" : "=a" (l), "=d" (h));
     return (unsigned long long)h<<32|l;
+#elif defined(__i386__)
+    unsigned int ret;
+    __asm__ volatile ("rdtsc" : "=A" (ret) );
+    return ret;
+#elif defined(__ARM_ARCH_7A__)
+    uint32_t r = 0;
+    asm volatile("mrc p15, 0, %0, c9, c13, 0" : "=r"(r) );
+    return r;
+#elif defined(__AARCH64EL__)
+    uint64_t b;
+    asm volatile( "mrs %0, pmccntr_el0" : "=r"(b) :: "memory" );
+    return b;
+#else
+    return 0;
 #endif
 }
 


### PR DESCRIPTION
you may check 
- http://git.videolan.org/gitweb.cgi/x264.git/?p=x264.git;a=blob;f=tools/checkasm.c;h=f6d0ad981f28d049895d502a38351eed535019ae;hb=HEAD
- https://github.com/couchbase/gperftools/blob/master/src/base/cycleclock.h
