### PR TITLE
isNoUnknownAccelMode: c1/M11 is inistialized as 0 size

### DIFF
--- a/hrplib/hrpModel/ForwardDynamicsCBM.cpp
+++ b/hrplib/hrpModel/ForwardDynamicsCBM.cpp
@@ -695,6 +695,8 @@ void ForwardDynamicsMM::solveUnknownAccels(Link* link, const Vector3& fext, cons
 
 void ForwardDynamicsMM::solveUnknownAccels(const Vector3& fext, const Vector3& tauext)
 {
+    if(isNoUnknownAccelMode){ return ; }
+
     if(unknown_rootDof){
         c1.head(3)      = fext;
         c1.segment(3,3) = tauext;


### PR DESCRIPTION
```
Thread 1 "hrpsys-simulato" received signal SIGSEGV, Segmentation fault.
0x00007ffff765cab9 in Eigen::ColPivHouseholderQR<Eigen::Matrix<double, -1, -1, 0, -1, -1> >::computeInPlace() ()
   from /home/user/catkin_ws/devel/lib/libhrpModel-3.1.so.0
(gdb) where
   from /home/user/catkin_ws/devel/lib/libhrpModel-3.1.so.0
   from /home/user/catkin_ws/devel/lib/libhrpModel-3.1.so.0
```