### PR TITLE
[hrpCollision] add ColdetModelPair::operator=()

### DIFF
--- a/hrplib/hrpCollision/ColdetModelPair.cpp
+++ b/hrplib/hrpCollision/ColdetModelPair.cpp
@@ -967,3 +967,10 @@ int ColdetModelPair::calculateIntersection(std::vector<float> &x, std::vector<fl
 
 	return t.size();
 }
+
+ColdetModelPair& ColdetModelPair::operator=(const ColdetModelPair& org)
+{
+    collisionPairInserter = new CollisionPairInserter;
+    set(org.models[0], org.models[1]);
+    tolerance_ = org.tolerance_;
+}

--- a/hrplib/hrpCollision/ColdetModelPair.h
+++ b/hrplib/hrpCollision/ColdetModelPair.h
@@ -83,6 +83,7 @@ namespace hrp {
 	bool isInsideTriangle(float x, float y, const std::vector<float> &vx, const std::vector<float> &vy);
 
 	int calculateIntersection(std::vector<float> &x, std::vector<float> &y, float radius, float x1, float y1, float x2, float y2);
+        ColdetModelPair& operator=(const ColdetModelPair& cmp);
 
       private:
         std::vector<collision_data>& detectCollisionsSub(bool detectAllContacts);


### PR DESCRIPTION
This PR adds ColdetModelPair::operator=() since ColdetModelPair::collisionPairInserter( a pointer to a collisionpairinserter object) points an object in the copy source object even after the copy source object is destroyed.
