### PR TITLE
Always use locale-free variant of strtod

### DIFF
--- a/hrplib/hrpUtil/EasyScanner.cpp
+++ b/hrplib/hrpUtil/EasyScanner.cpp
@@ -34,6 +34,26 @@ static inline double mystrtod(const char* nptr, char** endptr)
         sign = -1.0;
         nptr++;
     }
+    if(*nptr == 'n' || *nptr == 'N')
+    {
+      nptr++;
+      if(*nptr == 'a' || *nptr == 'A')
+      {
+        nptr++;
+        if(*nptr == 'n' || *nptr == 'N')
+        {
+          nptr++;
+          *endptr = (char *)nptr;
+          return NAN;
+        }
+      }
+      else
+      {
+        valid = false;
+        *endptr = (char *)org;
+        return 0;
+      }
+    }
     if(isdigit((unsigned char)*nptr)){
         valid = true;
         do {

--- a/hrplib/hrpUtil/EasyScanner.cpp
+++ b/hrplib/hrpUtil/EasyScanner.cpp
@@ -19,11 +19,9 @@ using namespace boost;
 using namespace hrp;
 
 
-// Replacement for 'strtod()' function in Visual C++
-// This is neccessary because the implementation of VC++6.0 uses 'strlen()' in the function,
-// so that it becomes too slow for a string buffer which has long length.
-#ifdef _MSC_VER
-static double mystrtod(const char* nptr, char** endptr)
+// Replacement for 'strtod()' function
+// This is necessary for a locale-free version
+static inline double mystrtod(const char* nptr, char** endptr)
 {
     const char* org = nptr;
     bool valid = false;
@@ -83,11 +81,6 @@ static double mystrtod(const char* nptr, char** endptr)
     }
     return sign * value;
 }
-#else
-static inline double mystrtod(const char* nptr, char** endptr) {
-    return strtod(nptr, endptr);
-}
-#endif
 
 
 std::string EasyScanner::Exception::getFullMessage()


### PR DESCRIPTION
In some environment (e.g. within Choreonoid with a locale that doesn't have "." as a decimal separator), the VRML parser will fail to parse decimal numbers correctly leading to problems that are difficult to diagnostic.

As far as I can see, float parsing happens within the EasyParser class, ultimately using the `strtod` function. Howver, `strtod` is locale-dependent so this PR avoids calling it. This is already the case on Windows (for other reasons) so I'm just re-using the Windows implementation for every platform.

In some local benchmarkings I did, the current MSVC version of the function actually out-performs `strtod` but numerical results are slightly different (the difference is around 1e-11 difference)