### PR TITLE
Fix missing return statement

### DIFF
--- a/server/ModelLoader/ColladaWriter.h
+++ b/server/ModelLoader/ColladaWriter.h
@@ -244,6 +244,7 @@ public:
             return false;
         }
         _WriteBindingsInstance_kinematics_scene(_scene.kiscene,bodyInfo,iasout->vaxissids,iasout->vkinematicsbindings);
+        return true;
     }
 
     /// \brief Write kinematic body in a given scene


### PR DESCRIPTION
This PR adds a return statement in the `ColladaWriter::Write` method. Without this, GCC generates wrong code on (at least) `O2` and `O3` optimization levels on Ubuntu 20.04 and the `openhrp-export-collada` executable is broken.