### PR TITLE
[server/ModelLoader/projectGenerator.cpp] write peridoic.rate to conf file

### DIFF
--- a/server/ModelLoader/projectGenerator.cpp
+++ b/server/ModelLoader/projectGenerator.cpp
@@ -630,6 +630,7 @@ int main (int argc, char** argv)
       std::fstream s(conf_file.c_str(), std::ios::out);
   
       s << "model: file://" << filenames[0] << std::endl;
+      s << "exec_cxt.periodic.rate: " << static_cast<size_t>(1/atof(dt.c_str())+0.5) << std::endl; // rounding to specify integer rate value
       s << "dt: " << dt << std::endl;
       s << conf_file_option << std::endl;
       std::cerr << "Writing conf files to ....... " << conf_file << std::endl;


### PR DESCRIPTION
https://github.com/start-jsk/rtmros_tutorials/issues/542
https://github.com/start-jsk/rtmros_common/issues/1109
https://github.com/start-jsk/rtmros_common/issues/408#issuecomment-864567377

`openhrp-project-generator)`が、`exec_cxt.periodic.rate`を、RobotHardware.confファイルに出力するのに加えて、.confファイルにも出力するようにする変更です.